### PR TITLE
Change deprecated pushHandler to prependHandler

### DIFF
--- a/src/support/exceptions.php
+++ b/src/support/exceptions.php
@@ -34,7 +34,7 @@ function load_whoops() {
 	$whoops     = new Run();
 	$error_page = new PrettyPageHandler();
 	$error_page->setEditor( 'sublime' );
-	$whoops->pushHandler( $error_page );
+	$whoops->prependHandler( $error_page );
 	$whoops->register();
 }
 


### PR DESCRIPTION
In function load_whoops(), I get a note in PhpStorm that pushHandler is deprecated.
After some digging, I found it in https://github.com/filp/whoops/blob/master/src/Whoops/Run.php on lines 43-54.
Specifically:
```
* @deprecated use appendHandler and prependHandler instead
     */
    public function pushHandler($handler)
    {
        return $this->prependHandler($handler);
    }
```